### PR TITLE
LNX-124 Adapt to atomic `Push`

### DIFF
--- a/entity/Entity.gd
+++ b/entity/Entity.gd
@@ -14,20 +14,6 @@ func _populate(attributes_json: Dictionary):
 		if attributes_json.has(accepted_attribute):
 			var attribute = "_" + accepted_attribute
 			var attribute_value = self.get(attribute)
-			if attribute_value is Array:
-				var internal_type = attribute_value.get_typed_class_name()
-				if internal_type is int or internal_type is float or internal_type is bool or internal_type is String:
-					for element in attributes_json.get(accepted_attribute):
-						attribute_value.append(element)
-				elif internal_type is Vector2:
-					for element in attributes_json.get(accepted_attribute):
-						var vector2 = Vector2(element.get("x"), element.get("y"))
-						attribute_value.append(vector2)
-				elif internal_type is LynxEntity:
-					for element in attributes_json.get(accepted_attribute):
-						attribute_value.append(entity_deserializer.deserialize(element))
-				else:
-					print("[ERROR] Unknown Array attribute type when populating")
 			if attribute_value is int or attribute_value is float or attribute_value is bool or attribute_value is String:
 				self.set(attribute, attributes_json.get(accepted_attribute))
 			elif attribute_value is Vector2:
@@ -35,6 +21,25 @@ func _populate(attributes_json: Dictionary):
 				self.set(attribute, vector2)
 			elif attribute_value is LynxEntity:
 				self.set(attribute, entity_deserializer.deserialize(attributes_json.get(accepted_attribute)))
+			elif attribute_value is Array[int]:
+				for element in attributes_json.get(accepted_attribute):
+					attribute_value.append(int(element))
+			elif attribute_value is Array[float]:
+				for element in attributes_json.get(accepted_attribute):
+					attribute_value.append(float(element))
+			elif attribute_value is Array[bool]:
+				for element in attributes_json.get(accepted_attribute):
+					attribute_value.append(bool(element))
+			elif attribute_value is Array[String]:
+				for element in attributes_json.get(accepted_attribute):
+					attribute_value.append(String(element))
+			elif attribute_value is Array[Vector2]:
+				for element in attributes_json.get(accepted_attribute):
+					var vector2 = Vector2(element.get("x"), element.get("y"))
+					attribute_value.append(vector2)
+			elif attribute_value is Array[LynxEntity]:
+				for element in attributes_json.get(accepted_attribute):
+					attribute_value.append(entity_deserializer.deserialize(element))
 			else:
 				print("[ERROR] Unknown attribute type when populating")
 

--- a/entity/action/push/Push.gd
+++ b/entity/action/push/Push.gd
@@ -2,9 +2,10 @@ extends LynxAction
 
 var _object_id = int()
 var _direction = Vector2()
+var _pushed_object_ids: Array[int] = []
 
 func _init():
-	self.accepted_attributes = ["object_id", "direction"]
+	self.accepted_attributes = ["object_id", "direction", "pushed_object_ids"]
 	
 func _execute():
 	var object = get_parent().object
@@ -24,3 +25,15 @@ func _execute():
 		object.get_node("AnimatedSprite2D").play()
 		# TODO: animation should play for 0.5 seconds, now it plays for 0 seconds
 		object.get_node("AnimatedSprite2D").stop()
+	
+	# TODO: change to relative paths
+	var objects_container = get_node("/root/Scene/WorldUpdater").objects_container
+	var entity_mapper = get_node("/root/Scene/WorldUpdater/StateGetter/EntityDeserializer/EntityMapper")
+	
+	for pushed_object_id in _pushed_object_ids:
+		var move = entity_mapper.map_entity_type_to_node("Move").instantiate()
+		move._object_id = pushed_object_id
+		move._movement = self._direction
+		
+		var pushed_object = objects_container.get_node(str(pushed_object_id))
+		pushed_object.get_node("ActionQueue").add_child(move)


### PR DESCRIPTION
* previously, after `Push` was applied to the scene, server sent one `Push` action and x `Move` actions (where x equals number of pushable objects standing on a `Square`)
* this was **VERY** problematic due to delayed nature of pending actions
* additionally, fixed `Array` deserialization