### PR TITLE
Add separate function for tile deserialization, fix error message

### DIFF
--- a/scene/world_updater/SceneRecreator.gd
+++ b/scene/world_updater/SceneRecreator.gd
@@ -8,14 +8,13 @@ extends Node
 func recreate_scene(scene_json):
 	for entity_json in scene_json["entities"]:
 		var entity = entity_deserializer.deserialize(entity_json)
-		
 		if !entity:
-			print("[ERROR] Could not deserialize Entity")
 			continue
 		
 		# TODO: this could be done at beginning of the loop by checking type key value
 		if !entity is LynxObject:
 			print("[ERROR] Entity could not be recreated, because it is not an Object")
+			entity.queue_free()
 			continue
 		
 		objects_container.add_child(entity)

--- a/scene/world_updater/SceneRecreator.gd
+++ b/scene/world_updater/SceneRecreator.gd
@@ -12,7 +12,7 @@ func recreate_scene(scene_json):
 			continue
 		
 		# TODO: this could be done at beginning of the loop by checking type key value
-		if !entity is LynxObject:
+		if not (entity is LynxObject):
 			print("[ERROR] Entity could not be recreated, because it is not an Object")
 			entity.queue_free()
 			continue

--- a/scene/world_updater/entity_deserializer/EntityDeserializer.gd
+++ b/scene/world_updater/entity_deserializer/EntityDeserializer.gd
@@ -31,8 +31,14 @@ func deserialize_object(attributes: Dictionary):
 	return entity_instance
 
 func deserialize_tile(attributes: Dictionary):
-		tile_setter.set_tile(attributes.name, Vector2i(attributes.position.get("x"), attributes.position.get("y")))
-		return null # no entity to be instantiated
+	if not attributes.has("name"):
+		print("[ERROR] No Tile name attribute when deserializing")
+		return null
+	if not attributes.has("position") or not attributes.position.has("x") or not attributes.position.has("y"):
+		print("[ERROR] No Tile position attribute when deserializing")
+		return null
+	tile_setter.set_tile(attributes.name, Vector2i(attributes.position.get("x"), attributes.position.get("y")))
+	return null
 
 func deserialize(entity_json: Dictionary):
 	if not entity_json.has("type"):

--- a/scene/world_updater/entity_deserializer/EntityDeserializer.gd
+++ b/scene/world_updater/entity_deserializer/EntityDeserializer.gd
@@ -5,54 +5,49 @@ extends Node
 @onready var entity_mapper = get_node("EntityMapper")
 var json = JSON.new()
 
-func deserialize_action(entity_json: Dictionary):
-	if not entity_json.has("attributes"):
-		print("[ERROR] No Entity attributes when deserializing")
-		return null
-	
-	var attributes = entity_json["attributes"]
-	var entity = entity_mapper.map_entity_type_to_node(entity_json.get("type"))
+func deserialize_action(attributes: Dictionary, type: String):
+	var entity = entity_mapper.map_entity_type_to_node(type)
 	if not entity:
-		print("[ERROR] Deserializing unknown action type: " + entity_json.get("type"))
+		print("[ERROR] Deserializing unknown action type: " + type)
 		return null
 	
 	var entity_instance = entity.instantiate()
 	entity_instance._populate(attributes)
 	return entity_instance
 
-func deserialize_object(entity_json: Dictionary):
-	if not entity_json.has("attributes"):
-		print("[ERROR] No Entity attributes when deserializing")
-		return null
-	
-	var attributes = entity_json["attributes"]
-	
+func deserialize_object(attributes: Dictionary):
 	if not attributes.has("name"):
-		print("[ERROR] No Entity name attribute when deserializing")
+		print("[ERROR] No Object name attribute when deserializing")
 		return null
-	
-	# it is walkable, so we set tilemap
-	if attributes.has("walkable") and attributes.walkable:
-		tile_setter.set_tile(attributes.name, Vector2i(attributes.position.get("x"), attributes.position.get("y")))
-		return null # TODO change the logic so that we can decouple deserialization and instatiation of entities, and we can handle tiles
-	
 	# map entity name to packed tscn
 	var entity = entity_mapper.map_entity_type_to_node(attributes.get("name"))
 	
 	if not entity:
-		print("[ERROR] Deserializing unknown Entity name: " + attributes.get("name"))
+		print("[ERROR] Deserializing unknown Object name: " + attributes.get("name"))
 		return null
 	
 	var entity_instance = entity.instantiate()
 	entity_instance._populate(attributes)
 	return entity_instance
+
+func deserialize_tile(attributes: Dictionary):
+		tile_setter.set_tile(attributes.name, Vector2i(attributes.position.get("x"), attributes.position.get("y")))
+		return null # no entity to be instantiated
 
 func deserialize(entity_json: Dictionary):
 	if not entity_json.has("type"):
 		print("[ERROR] No Entity type when deserializing")
 		return null
 	
+	if not entity_json.has("attributes"):
+		print("[ERROR] No Entity attributes when deserializing")
+		return null
+	
+	var attributes = entity_json["attributes"]
+	
 	if entity_json["type"] == "Object":
-		return deserialize_object(entity_json)
+		if attributes.has("walkable") and attributes.walkable:
+			return deserialize_tile(attributes)
+		return deserialize_object(attributes)
 	else:
-		return deserialize_action(entity_json)
+		return deserialize_action(attributes, entity_json["type"])


### PR DESCRIPTION
Decoupling entity deserialization and tile deserialization logic would be very inefficient.
Removed the unnecesary error, now we don't get pointless error about failing to deserialize entity.
Errors with deserializing are handled by EntityDeserializer.

Moved tile logic to separate function.