### PR TITLE
Fix global queue

### DIFF
--- a/scene/world_updater.tscn
+++ b/scene/world_updater.tscn
@@ -49,14 +49,9 @@ autostart = true
 
 [node name="GlobalActionQueue" type="Node" parent="."]
 
-[node name="ExecuteActionTimer" type="Timer" parent="GlobalActionQueue"]
-wait_time = 0.5
-autostart = true
-
 [node name="Queue" type="Node" parent="GlobalActionQueue"]
 script = ExtResource("10_if4lj")
 
 [connection signal="request_completed" from="StateGetter/GetStateHTTPRequest" to="StateGetter" method="_on_get_state_http_request_request_completed"]
 [connection signal="timeout" from="StateGetter/GetStateTimer" to="StateGetter" method="_on_get_state_timer_timeout"]
 [connection signal="timeout" from="Ticker/PostTickTimer" to="Ticker" method="_on_post_tick_timer_timeout"]
-[connection signal="timeout" from="GlobalActionQueue/ExecuteActionTimer" to="GlobalActionQueue/Queue" method="_on_execute_action_timer_timeout"]

--- a/scene/world_updater/GlobalActionQueue.gd
+++ b/scene/world_updater/GlobalActionQueue.gd
@@ -1,10 +1,5 @@
 extends Node
 
-func _on_execute_action_timer_timeout():
-	if self.get_child_count() == 0:
-		return
-	var next_action = self.get_child(0) # first child (action) from queue
-	if !next_action:
-		return
-	next_action.apply()
-	
+func _process(delta):
+	for action in get_children():
+		action.apply()


### PR DESCRIPTION
CreateObject actions going into global queue weren't executed at the right time, which led to bugs such as trying to push nonexisting object. Now global queue executes all actions in each frame, so that there are not such issues anymore.