### PR TITLE
LNX-153 Add better http request error handling on the godot side handle timeouts

### DIFF
--- a/entity/action/Action.gd
+++ b/entity/action/Action.gd
@@ -11,3 +11,6 @@ func apply():
 # overide method, executes action
 func _execute():
 	pass
+	
+func _post_populate():
+	self.get_node("ExecuteActionTimer").wait_time = Globals.DEFAULT_ACTION_SPEED

--- a/entity/action/create_object/CreateObject.gd
+++ b/entity/action/create_object/CreateObject.gd
@@ -1,6 +1,6 @@
 extends LynxAction
 
-var _serialized_object = int()
+var _serialized_object = String()
 var json = JSON.new()
 
 func _init():
@@ -21,3 +21,4 @@ func _execute():
 	Globals.WORLD_UPDATER.objects_container.add_child(entity)
 	entity._post_populate()
 	
+	Globals.OBJECTS_IN_CREATION.erase(entity._id)

--- a/entity/action/create_object/CreateObject.gd
+++ b/entity/action/create_object/CreateObject.gd
@@ -21,4 +21,4 @@ func _execute():
 	Globals.WORLD_UPDATER.objects_container.add_child(entity)
 	entity._post_populate()
 	
-	Globals.OBJECTS_IN_CREATION.erase(entity._id)
+	Globals.OBJECTS_IN_CREATION.erase(int(entity._id))

--- a/entity/action/move/Move.gd
+++ b/entity/action/move/Move.gd
@@ -25,7 +25,7 @@ func _execute():
 		object.get_node("AnimatedSprite2D").set_frame(0)
 		
 	
-	await object.move(Vector2i(object._position) + Vector2i(self._direction), Globals.DEFAULT_ACTION_SPEED - 0.1 / Globals.ACTION_SPEED_MULTIPLIER)
+	await object.move(Vector2i(object._position) + Vector2i(self._direction), (Globals.DEFAULT_ACTION_SPEED - 0.1) / Globals.ACTION_SPEED_MULTIPLIER)
 	
 	if object.has_node("AnimatedSprite2D"):
 		object.get_node("AnimatedSprite2D").stop()

--- a/entity/action/move/Move.gd
+++ b/entity/action/move/Move.gd
@@ -25,7 +25,7 @@ func _execute():
 		object.get_node("AnimatedSprite2D").set_frame(0)
 		
 	
-	await object.move(Vector2i(object._position) + Vector2i(self._direction))
+	await object.move(Vector2i(object._position) + Vector2i(self._direction), Globals.DEFAULT_ACTION_SPEED - 0.1 / Globals.ACTION_SPEED_MULTIPLIER)
 	
 	if object.has_node("AnimatedSprite2D"):
 		object.get_node("AnimatedSprite2D").stop()

--- a/entity/action/move/Move.gd
+++ b/entity/action/move/Move.gd
@@ -25,7 +25,7 @@ func _execute():
 		object.get_node("AnimatedSprite2D").set_frame(0)
 		
 	
-	await object.move(Vector2i(object._position) + Vector2i(self._direction), 0.4)
+	await object.move(Vector2i(object._position) + Vector2i(self._direction))
 	
 	if object.has_node("AnimatedSprite2D"):
 		object.get_node("AnimatedSprite2D").stop()

--- a/entity/action/push/Push.gd
+++ b/entity/action/push/Push.gd
@@ -29,6 +29,6 @@ func _execute():
 	for pushed_object_id in _pushed_object_ids:
 		var pushed_object = Globals.WORLD_UPDATER.objects_container.get_object_by_id(pushed_object_id)
 		if pushed_object:
-			await pushed_object.move(Vector2i(pushed_object._position) + Vector2i(self._direction))
+			await pushed_object.move(Vector2i(pushed_object._position) + Vector2i(self._direction), Globals.DEFAULT_ACTION_SPEED - 0.1 / Globals.ACTION_SPEED_MULTIPLIER)
 		else:
 			push_error("[ERROR] Could not get pushed object with id: " + str(pushed_object_id))

--- a/entity/action/push/Push.gd
+++ b/entity/action/push/Push.gd
@@ -27,14 +27,7 @@ func _execute():
 		object.get_node("AnimatedSprite2D").set_animation(animation)
 	
 	for pushed_object_id in _pushed_object_ids:
-		# sometimes we might need to wait a few frames for wood to appear
-		var pushed_object = null
-		var retry_counter = 0
-		while pushed_object == null || retry_counter <= 5:
-			pushed_object = Globals.WORLD_UPDATER.objects_container.get_object_by_id(pushed_object_id)
-			await get_tree().process_frame
-			retry_counter += 1
-		
+		var pushed_object = Globals.WORLD_UPDATER.objects_container.get_object_by_id(pushed_object_id)
 		if pushed_object:
 			await pushed_object.move(Vector2i(pushed_object._position) + Vector2i(self._direction), 0.4)
 		else:

--- a/entity/action/push/Push.gd
+++ b/entity/action/push/Push.gd
@@ -29,6 +29,6 @@ func _execute():
 	for pushed_object_id in _pushed_object_ids:
 		var pushed_object = Globals.WORLD_UPDATER.objects_container.get_object_by_id(pushed_object_id)
 		if pushed_object:
-			await pushed_object.move(Vector2i(pushed_object._position) + Vector2i(self._direction), Globals.DEFAULT_ACTION_SPEED - 0.1 / Globals.ACTION_SPEED_MULTIPLIER)
+			await pushed_object.move(Vector2i(pushed_object._position) + Vector2i(self._direction), (Globals.DEFAULT_ACTION_SPEED - 0.1) / Globals.ACTION_SPEED_MULTIPLIER)
 		else:
 			push_error("[ERROR] Could not get pushed object with id: " + str(pushed_object_id))

--- a/entity/action/push/Push.gd
+++ b/entity/action/push/Push.gd
@@ -29,6 +29,6 @@ func _execute():
 	for pushed_object_id in _pushed_object_ids:
 		var pushed_object = Globals.WORLD_UPDATER.objects_container.get_object_by_id(pushed_object_id)
 		if pushed_object:
-			await pushed_object.move(Vector2i(pushed_object._position) + Vector2i(self._direction), 0.4)
+			await pushed_object.move(Vector2i(pushed_object._position) + Vector2i(self._direction))
 		else:
 			push_error("[ERROR] Could not get pushed object with id: " + str(pushed_object_id))

--- a/entity/action/push/Push.gd
+++ b/entity/action/push/Push.gd
@@ -27,7 +27,7 @@ func _execute():
 		object.get_node("AnimatedSprite2D").set_animation(animation)
 	
 	for pushed_object_id in _pushed_object_ids:
-		var pushed_object = Globals.WORLD_UPDATER.objects_container.get_object_by_id(pushed_object_id)
+		var pushed_object = await Globals.WORLD_UPDATER.objects_container.get_object_by_id(pushed_object_id)
 		if pushed_object:
 			await pushed_object.move(Vector2i(pushed_object._position) + Vector2i(self._direction), (Globals.DEFAULT_ACTION_SPEED - 0.1) / Globals.ACTION_SPEED_MULTIPLIER)
 		else:

--- a/entity/object/Object.gd
+++ b/entity/object/Object.gd
@@ -16,12 +16,17 @@ func _post_populate():
 	self.position += Vector2(Globals.TILE_SIZE / 2)
 
 # accepts position in tile coordinates 
-func move(_target_position: Vector2i, duration: float):
+func move(_target_position: Vector2i):
 	var tween = get_tree().create_tween()
-	var target_position = Vector2(_target_position * Globals.TILE_SIZE)
 	
+	var target_position = Vector2(_target_position * Globals.TILE_SIZE)
 	target_position = target_position.snapped(Globals.TILE_SIZE)
 	target_position += Vector2(Globals.TILE_SIZE / 2)
-	tween.tween_property(self, "position", target_position, duration / Globals.ACTION_SPEED_MULTIPLIER).set_trans(Tween.TRANS_LINEAR)
+	
+	var duration = Globals.DEFAULT_ACTION_SPEED - 0.1 / Globals.ACTION_SPEED_MULTIPLIER
+	
+	tween.tween_property(self, "position", target_position, duration).set_trans(Tween.TRANS_LINEAR)
+	
 	await tween.finished
+	
 	self._position = _target_position

--- a/entity/object/Object.gd
+++ b/entity/object/Object.gd
@@ -22,6 +22,6 @@ func move(_target_position: Vector2i, duration: float):
 	
 	target_position = target_position.snapped(Globals.TILE_SIZE)
 	target_position += Vector2(Globals.TILE_SIZE / 2)
-	tween.tween_property(self, "position", target_position, 0.4).set_trans(Tween.TRANS_LINEAR)
+	tween.tween_property(self, "position", target_position, duration / Globals.ACTION_SPEED_MULTIPLIER).set_trans(Tween.TRANS_LINEAR)
 	await tween.finished
 	self._position = _target_position

--- a/entity/object/Object.gd
+++ b/entity/object/Object.gd
@@ -16,14 +16,12 @@ func _post_populate():
 	self.position += Vector2(Globals.TILE_SIZE / 2)
 
 # accepts position in tile coordinates 
-func move(_target_position: Vector2i):
+func move(_target_position: Vector2i, duration: float):
 	var tween = get_tree().create_tween()
 	
 	var target_position = Vector2(_target_position * Globals.TILE_SIZE)
 	target_position = target_position.snapped(Globals.TILE_SIZE)
 	target_position += Vector2(Globals.TILE_SIZE / 2)
-	
-	var duration = Globals.DEFAULT_ACTION_SPEED - 0.1 / Globals.ACTION_SPEED_MULTIPLIER
 	
 	tween.tween_property(self, "position", target_position, duration).set_trans(Tween.TRANS_LINEAR)
 	

--- a/entity/object/log.tscn
+++ b/entity/object/log.tscn
@@ -1,14 +1,29 @@
-[gd_scene load_steps=4 format=3 uid="uid://c47qlcbmfsr1m"]
+[gd_scene load_steps=6 format=3 uid="uid://c47qlcbmfsr1m"]
 
-[ext_resource type="Texture2D" uid="uid://cfdh754xr2c68" path="res://assets/NinjaAdventure/Items/Food/Beaf.png" id="1_88agp"]
 [ext_resource type="Script" path="res://entity/object/log/Log.gd" id="1_lq4sp"]
+[ext_resource type="Texture2D" uid="uid://ca3n0ke6737vk" path="res://assets/NinjaAdventure/Backgrounds/Tilesets/TilesetHouse.png" id="2_3cfmd"]
 [ext_resource type="Script" path="res://entity/object/agent/ActionQueue.gd" id="3_k4g3e"]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_fab68"]
+atlas = ExtResource("2_3cfmd")
+region = Rect2(496, 288, 16, 16)
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_tglnp"]
+animations = [{
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_fab68")
+}],
+"loop": true,
+"name": &"default",
+"speed": 5.0
+}]
 
 [node name="Log" type="Node2D"]
 script = ExtResource("1_lq4sp")
 
-[node name="Sprite2D" type="Sprite2D" parent="."]
-texture = ExtResource("1_88agp")
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+sprite_frames = SubResource("SpriteFrames_tglnp")
 
 [node name="ActionQueue" type="Node" parent="."]
 script = ExtResource("3_k4g3e")

--- a/globals.gd
+++ b/globals.gd
@@ -3,3 +3,5 @@ extends Node
 var TILE_SIZE: Vector2i
 var SERVER_ADDRESS: String = "http://127.0.0.1:8555/" # localhost by default, to be changed later
 var WORLD_UPDATER: Node
+var ACTION_SPEED_MULTIPLIER: int
+var OBJECTS_IN_CREATION: Array[float] = []

--- a/globals.gd
+++ b/globals.gd
@@ -3,6 +3,7 @@ extends Node
 var TILE_SIZE: Vector2i
 var SERVER_ADDRESS: String = "http://127.0.0.1:8555/" # localhost by default, to be changed later
 var WORLD_UPDATER: Node
+var DEFAULT_ACTION_SPEED: float = 0.5
 var ACTION_SPEED_MULTIPLIER: int
 var OBJECTS_IN_CREATION: Array[float] = []
 var BUSY_HTTP_STATUSES: Array[int] = [HTTPClient.STATUS_CONNECTING, HTTPClient.STATUS_REQUESTING]

--- a/globals.gd
+++ b/globals.gd
@@ -5,3 +5,4 @@ var SERVER_ADDRESS: String = "http://127.0.0.1:8555/" # localhost by default, to
 var WORLD_UPDATER: Node
 var ACTION_SPEED_MULTIPLIER: int
 var OBJECTS_IN_CREATION: Array[float] = []
+var BUSY_HTTP_STATUSES: Array[int] = [HTTPClient.STATUS_CONNECTING, HTTPClient.STATUS_REQUESTING]

--- a/globals.gd
+++ b/globals.gd
@@ -5,5 +5,5 @@ var SERVER_ADDRESS: String = "http://127.0.0.1:8555/" # localhost by default, to
 var WORLD_UPDATER: Node
 var DEFAULT_ACTION_SPEED: float = 0.5
 var ACTION_SPEED_MULTIPLIER: int
-var OBJECTS_IN_CREATION: Array[float] = []
+var OBJECTS_IN_CREATION: Array[int] = []
 var BUSY_HTTP_STATUSES: Array[int] = [HTTPClient.STATUS_CONNECTING, HTTPClient.STATUS_REQUESTING]

--- a/scene/AgentCreator.gd
+++ b/scene/AgentCreator.gd
@@ -9,7 +9,7 @@ func post_agent(new_agent):
 	var payload_json = {"serialized_object": JSON.stringify(new_agent.serialize())}
 	var payload_string = JSON.stringify(payload_json)
 	var headers = ["Content-Type: application/json"]
-	if post_agent_http_request.get_http_client_status() not in [HTTPClient.STATUS_CONNECTING, HTTPClient.STATUS_REQUESTING]:
+	if post_agent_http_request.get_http_client_status() not in Globals.BUSY_HTTP_STATUSES:
 		var error = post_agent_http_request.request(Globals.SERVER_ADDRESS + "add_object", headers, HTTPClient.METHOD_POST, payload_string)
 		if error != OK:
 			push_error("[ERROR] Could not POST Agent")

--- a/scene/AgentCreator.gd
+++ b/scene/AgentCreator.gd
@@ -10,9 +10,9 @@ func post_agent(new_agent):
 	var payload_string = JSON.stringify(payload_json)
 	var headers = ["Content-Type: application/json"]
 	if post_agent_http_request.get_http_client_status() not in Globals.BUSY_HTTP_STATUSES:
-		var error = post_agent_http_request.request(Globals.SERVER_ADDRESS + "add_object", headers, HTTPClient.METHOD_POST, payload_string)
-		if error != OK:
-			push_error("[ERROR] Could not POST Agent")
+		var result = post_agent_http_request.request(Globals.SERVER_ADDRESS + "add_object", headers, HTTPClient.METHOD_POST, payload_string)
+		if result != OK:
+			push_error("[ERROR] Could not POST Agent: " + str(result))
 
 func create_agent(_code, _position = Vector2(0, 0), _id = randi(), _owner = ""):
 	var new_agent = Agent.instantiate()

--- a/scene/AgentCreator.gd
+++ b/scene/AgentCreator.gd
@@ -9,7 +9,7 @@ func post_agent(new_agent):
 	var payload_json = {"serialized_object": JSON.stringify(new_agent.serialize())}
 	var payload_string = JSON.stringify(payload_json)
 	var headers = ["Content-Type: application/json"]
-	if post_agent_http_request.get_http_client_status() != HTTPClient.STATUS_CONNECTING:
+	if post_agent_http_request.get_http_client_status() not in [HTTPClient.STATUS_CONNECTING, HTTPClient.STATUS_REQUESTING]:
 		var error = post_agent_http_request.request(Globals.SERVER_ADDRESS + "add_object", headers, HTTPClient.METHOD_POST, payload_string)
 		if error != OK:
 			push_error("[ERROR] Could not POST Agent")

--- a/scene/MapPopulator.gd
+++ b/scene/MapPopulator.gd
@@ -5,7 +5,7 @@ extends Node
 @onready var state_getter = get_node("../WorldUpdater").state_getter
 
 func post_populate():
-	if post_populate_http_request.get_http_client_status() not in [HTTPClient.STATUS_CONNECTING, HTTPClient.STATUS_REQUESTING]:
+	if post_populate_http_request.get_http_client_status() not in Globals.BUSY_HTTP_STATUSES:
 		var error = post_populate_http_request.request(post_populate_endpoint_url, [], HTTPClient.METHOD_POST)
 		if error != OK:
 			push_error("[ERROR] Could not POST populate")

--- a/scene/MapPopulator.gd
+++ b/scene/MapPopulator.gd
@@ -5,12 +5,12 @@ extends Node
 @onready var state_getter = get_node("../WorldUpdater").state_getter
 
 func post_populate():
-	if post_populate_http_request.get_http_client_status() != HTTPClient.STATUS_CONNECTING:
+	if post_populate_http_request.get_http_client_status() not in [HTTPClient.STATUS_CONNECTING, HTTPClient.STATUS_REQUESTING]:
 		var error = post_populate_http_request.request(post_populate_endpoint_url, [], HTTPClient.METHOD_POST)
 		if error != OK:
 			push_error("[ERROR] Could not POST populate")
 			return
-		self.state_getter.current_tick_hash = -1
+		self.state_getter.current_tick_number = -1
 
 
 func _on_ui_post_populate_map_requested():

--- a/scene/MapPopulator.gd
+++ b/scene/MapPopulator.gd
@@ -6,9 +6,9 @@ extends Node
 
 func post_populate():
 	if post_populate_http_request.get_http_client_status() not in Globals.BUSY_HTTP_STATUSES:
-		var error = post_populate_http_request.request(post_populate_endpoint_url, [], HTTPClient.METHOD_POST)
-		if error != OK:
-			push_error("[ERROR] Could not POST populate")
+		var result = post_populate_http_request.request(post_populate_endpoint_url, [], HTTPClient.METHOD_POST)
+		if result != OK:
+			push_error("[ERROR] Could not POST populate: " + str(result))
 			return
 		self.state_getter.current_tick_number = -1
 

--- a/scene/ObjectsContainer.gd
+++ b/scene/ObjectsContainer.gd
@@ -1,13 +1,20 @@
 extends Node2D
 
+func _await_creation_of_object(id: int):
+	while(id in Globals.OBJECTS_IN_CREATION):
+		await get_tree().process_frame
+
 func get_object_by_id(id: int):
+	_await_creation_of_object(id)
 	return get_node(str(id))
 	
 func remove_object_by_id(id: int):
-	var object = get_node(str(id))
+	var object = get_object_by_id(id)
 	if object:
 		remove_child(object)
 		object.queue_free()
+	else:
+		push_warning("[WARNING] Object could not be removed, because it does not exist")
 
 func get_objects_by_position(position: Vector2):
 	var objects: Array = []

--- a/scene/ObjectsContainer.gd
+++ b/scene/ObjectsContainer.gd
@@ -5,11 +5,11 @@ func _await_creation_of_object(id: int):
 		await get_tree().process_frame
 
 func get_object_by_id(id: int):
-	_await_creation_of_object(id)
+	await _await_creation_of_object(id)
 	return get_node(str(id))
 	
 func remove_object_by_id(id: int):
-	var object = get_object_by_id(id)
+	var object = await get_object_by_id(id)
 	if object:
 		remove_child(object)
 		object.queue_free()

--- a/scene/world_updater/DeltasApplier.gd
+++ b/scene/world_updater/DeltasApplier.gd
@@ -11,7 +11,7 @@ func _handle_create_object(entity):
 	Globals.OBJECTS_IN_CREATION.append(object_in_creation["attributes"]["id"])
 
 func _handle_global_action(entity):
-	if entity._type == "CreateObject":
+	if entity.get_name() == "CreateObject":
 		_handle_create_object(entity)
 	self.global_action_queue.add_child(entity)
 

--- a/scene/world_updater/DeltasApplier.gd
+++ b/scene/world_updater/DeltasApplier.gd
@@ -23,7 +23,7 @@ func apply_deltas(deltas_json):
 				continue
 				
 			while(entity._object_id in Globals.OBJECTS_IN_CREATION):
-				await get_tree().create_timer(0.01).timeout
+				await get_tree().process_frame
 			
 			var object = objects_container.get_object_by_id(entity._object_id)
 			

--- a/scene/world_updater/DeltasApplier.gd
+++ b/scene/world_updater/DeltasApplier.gd
@@ -21,12 +21,8 @@ func apply_deltas(deltas_json):
 				Globals.OBJECTS_IN_CREATION.append(object_in_creation["attributes"]["id"])
 				self.global_action_queue.add_child(entity)
 				continue
-				
-			while(entity._object_id in Globals.OBJECTS_IN_CREATION):
-				await get_tree().process_frame
 			
 			var object = objects_container.get_object_by_id(entity._object_id)
-			
 			if object:
 				object.get_node("ActionQueue").add_child(entity)
 			else:

--- a/scene/world_updater/DeltasApplier.gd
+++ b/scene/world_updater/DeltasApplier.gd
@@ -16,8 +16,14 @@ func apply_deltas(deltas_json):
 			push_error("[ERROR] Could not deserialize Entity")
 		if entity is LynxAction:
 			if not "_object_id" in entity:
+				json.parse(entity._serialized_object)
+				var object_in_creation = json.get_data()
+				Globals.OBJECTS_IN_CREATION.append(object_in_creation["attributes"]["id"])
 				self.global_action_queue.add_child(entity)
 				continue
+				
+			while(entity._object_id in Globals.OBJECTS_IN_CREATION):
+				await get_tree().create_timer(0.01).timeout
 			
 			var object = objects_container.get_object_by_id(entity._object_id)
 			

--- a/scene/world_updater/DeltasApplier.gd
+++ b/scene/world_updater/DeltasApplier.gd
@@ -8,7 +8,7 @@ var json = JSON.new()
 func _handle_create_object(entity):
 	json.parse(entity._serialized_object)
 	var object_in_creation = json.get_data()
-	Globals.OBJECTS_IN_CREATION.append(object_in_creation["attributes"]["id"])
+	Globals.OBJECTS_IN_CREATION.append(int(object_in_creation["attributes"]["id"]))
 
 func _handle_global_action(entity):
 	if entity.get_name() == "CreateObject":

--- a/scene/world_updater/DeltasApplier.gd
+++ b/scene/world_updater/DeltasApplier.gd
@@ -16,7 +16,7 @@ func _handle_global_action(entity):
 	self.global_action_queue.add_child(entity)
 
 func _handle_object_action(entity):
-	var object = objects_container.get_object_by_id(entity._object_id)
+	var object = await objects_container.get_object_by_id(entity._object_id)
 	if object:
 		object.get_node("ActionQueue").add_child(entity)
 	else:

--- a/scene/world_updater/StateGetter.gd
+++ b/scene/world_updater/StateGetter.gd
@@ -39,7 +39,7 @@ func _on_get_state_http_request_request_completed(_result, response_code, _heade
 
 # send get state requests every timer timeout (1s)
 func _on_get_state_timer_timeout():
-	if get_state_http_request.get_http_client_status() not in [HTTPClient.STATUS_CONNECTING, HTTPClient.STATUS_REQUESTING]:
+	if get_state_http_request.get_http_client_status() not in Globals.BUSY_HTTP_STATUSES:
 		var error = get_state_http_request.request(Globals.SERVER_ADDRESS + "?tick_number=" + str(current_tick_number))
 		if error != OK:
-			push_error("An error occurred in the get state HTTP request.")
+			push_error("[ERROR] Could not GET state")

--- a/scene/world_updater/StateGetter.gd
+++ b/scene/world_updater/StateGetter.gd
@@ -40,6 +40,6 @@ func _on_get_state_http_request_request_completed(_result, response_code, _heade
 # send get state requests every timer timeout (1s)
 func _on_get_state_timer_timeout():
 	if get_state_http_request.get_http_client_status() not in Globals.BUSY_HTTP_STATUSES:
-		var error = get_state_http_request.request(Globals.SERVER_ADDRESS + "?tick_number=" + str(current_tick_number))
-		if error != OK:
-			push_error("[ERROR] Could not GET state")
+		var result = get_state_http_request.request(Globals.SERVER_ADDRESS + "?tick_number=" + str(current_tick_number))
+		if result != OK:
+			push_error("[ERROR] Could not GET state: " + str(result))

--- a/scene/world_updater/StateGetter.gd
+++ b/scene/world_updater/StateGetter.gd
@@ -10,7 +10,7 @@ var current_tick_number: int = -1
 
 func _speed_up_actions():
 	for object in Globals.WORLD_UPDATER.objects_container.get_children():
-		object.get_node("ExecuteActionTimer").wait_time = 0.5 / Globals.ACTION_SPEED_MULTIPLIER
+		object.get_node("ExecuteActionTimer").wait_time = Globals.DEFAULT_ACTION_SPEED / Globals.ACTION_SPEED_MULTIPLIER
 		object.get_node("AnimatedSprite2D").speed_scale = Globals.ACTION_SPEED_MULTIPLIER
 
 func _handle_lag(old_tick_number, new_tick_number):

--- a/scene/world_updater/StateGetter.gd
+++ b/scene/world_updater/StateGetter.gd
@@ -6,24 +6,35 @@ extends Node
 @onready var scene_wiper = get_node("SceneWiper")
 
 var json = JSON.new()
-var current_tick_hash = -1
+var current_tick_number: int = -1
 
-# send get state requests every timer timeout (1s)
-func _on_get_state_timer_timeout():
-	if get_state_http_request.get_http_client_status() != HTTPClient.STATUS_CONNECTING:
-		var error = get_state_http_request.request(Globals.SERVER_ADDRESS + "?tick_number=" + str(current_tick_hash))
-		if error != OK:
-			push_error("An error occurred in the get state HTTP request.")
+func _speed_up_actions_after_lag(old_tick_number, new_tick_number):
+	Globals.ACTION_SPEED_MULTIPLIER = 1 if new_tick_number <= old_tick_number else new_tick_number - old_tick_number
+
+	for object in Globals.WORLD_UPDATER.objects_container.get_children():
+		object.get_node("ExecuteActionTimer").wait_time = 0.5 / Globals.ACTION_SPEED_MULTIPLIER
+		object.get_node("AnimatedSprite2D").speed_scale = Globals.ACTION_SPEED_MULTIPLIER
+		
+func _update_state(response):
+	if "scene" in response.keys():
+		json.parse(response["scene"])
+		scene_wiper.wipe()
+		scene_recreator.recreate_scene(json.get_data())
+	elif "deltas" in response.keys():
+		deltas_applier.apply_deltas(response["deltas"])
+	
+	_speed_up_actions_after_lag(current_tick_number, response["tick_number"])
+	current_tick_number = response["tick_number"]
 
 func _on_get_state_http_request_request_completed(_result, response_code, _headers, body):
 	if response_code == 200:
 		json.parse(body.get_string_from_utf8())
 		var response = json.get_data()
-		if "scene" in response.keys():
-			json.parse(response["scene"])
-			scene_wiper.wipe() # wipe the whole scene
-			scene_recreator.recreate_scene(json.get_data()) # we have outdated scene, recreate everything
-			current_tick_hash = response["tick_number"]
-		elif "deltas" in response.keys():
-			deltas_applier.apply_deltas(response["deltas"]) # just do deltas
-			current_tick_hash = response["tick_number"]
+		_update_state(response)
+
+# send get state requests every timer timeout (1s)
+func _on_get_state_timer_timeout():
+	if get_state_http_request.get_http_client_status() not in [HTTPClient.STATUS_CONNECTING, HTTPClient.STATUS_REQUESTING]:
+		var error = get_state_http_request.request(Globals.SERVER_ADDRESS + "?tick_number=" + str(current_tick_number))
+		if error != OK:
+			push_error("An error occurred in the get state HTTP request.")


### PR DESCRIPTION
Major changes::
* started checking if a http client is not requesting before creating a new http request
  * this way we can be sure that no request for state is started before the previous one is finished 
* fixed `CreateObject` race
  * when an object is being created, its `id` is added to `Globals.OBJECTS_IN_CREATION`
  * while the object's `id` is in `Globals.OBJECTS_IN_CREATION`, a wait is issued **(only for actions on that object, when trying to access it)**
  * when the object is finally created, its `id` is removed from `Globals.OBJECTS_IN_CREATION`
  * the wait and actions on the object can finally be executed
* added synchronisation
  * depending on tick difference, action execution and animation speed differs
  * e.g. if the client is 5 ticks behind (~500ms), actions are executed 5 times faster and animation speed is multiplied by 5
  * this makes it possible for the client to catch up, despite the lag

Minor changes:
* added `AnimatedSprite` to Log
* changed Log's sprite
* refactor, fixes, renaming