### PR TITLE
NOISSUE Remove get_object_by_id return value checks

### DIFF
--- a/addons/lynx_nodes/entity/action/move/Move.gd
+++ b/addons/lynx_nodes/entity/action/move/Move.gd
@@ -25,7 +25,7 @@ func _execute():
 		object.get_node("AnimatedSprite2D").set_frame(0)
 		
 	
-	await object.move(Vector2i(object._position) + Vector2i(self._direction), (Globals.DEFAULT_ACTION_SPEED - 0.1) / Globals.ACTION_SPEED_MULTIPLIER)
+	await object.move(Vector2i(object._position) + Vector2i(self._direction), Globals.DEFAULT_ACTION_SPEED / Globals.ACTION_SPEED_MULTIPLIER)
 	
 	if object.has_node("AnimatedSprite2D"):
 		object.get_node("AnimatedSprite2D").stop()

--- a/addons/lynx_nodes/entity/action/push/Push.gd
+++ b/addons/lynx_nodes/entity/action/push/Push.gd
@@ -28,7 +28,4 @@ func _execute():
 	
 	for pushed_object_id in _pushed_object_ids:
 		var pushed_object = await Globals.WORLD_UPDATER.objects_container.get_object_by_id(pushed_object_id)
-		if pushed_object:
-			await pushed_object.move(Vector2i(pushed_object._position) + Vector2i(self._direction), (Globals.DEFAULT_ACTION_SPEED - 0.1) / Globals.ACTION_SPEED_MULTIPLIER)
-		else:
-			push_error("[ERROR] Could not get pushed object with id: " + str(pushed_object_id))
+		await pushed_object.move(Vector2i(pushed_object._position) + Vector2i(self._direction), Globals.DEFAULT_ACTION_SPEED / Globals.ACTION_SPEED_MULTIPLIER)

--- a/addons/lynx_nodes/utils/scenes/speech_bubble/SpeechBubble.gd
+++ b/addons/lynx_nodes/utils/scenes/speech_bubble/SpeechBubble.gd
@@ -1,10 +1,9 @@
 extends Control
 
 func _on_visibility_timer_timeout():
-	self.visible= false
+	visible = false
 
 func show_text(text: String):
 	visible = true
 	get_node("RichTextLabel").text = text
 	get_node("VisibilityTimer").start(1)
-

--- a/scene/world_updater/DeltasApplier.gd
+++ b/scene/world_updater/DeltasApplier.gd
@@ -17,10 +17,7 @@ func _handle_global_action(entity):
 
 func _handle_object_action(entity):
 	var object = await objects_container.get_object_by_id(entity._object_id)
-	if object:
-		object.action_queue.add_child(entity)
-	else:
-		push_error("[ERROR] Could not get object to have applied action on with id: " + str(entity._object_id))
+	object.action_queue.add_child(entity)
 
 func apply_deltas(deltas_json):
 	json.parse(deltas_json)


### PR DESCRIPTION
Since we use await when getting an object by id, there's no need to check if we actually got it.